### PR TITLE
fix: global access and refresh tokens were written to the local config

### DIFF
--- a/src/commands/auth/login.js
+++ b/src/commands/auth/login.js
@@ -35,9 +35,9 @@ class LoginCommand extends ImsBaseCommand {
       }
 
       if (flags.ctx === CLI) {
-        const data = await context.getCli() || {}
-        data['$cli.bare-output'] = flags.bare
-        await context.setCli(data)
+        await context.setCli({
+          '$cli.bare-output': flags.bare
+        })
       }
 
       let token = await getToken(flags.ctx, flags.force)


### PR DESCRIPTION
## Description

This prevented `aio logout` from working correctly for the `$cli` context, if `aio login` was called again after the initial browser-based login.

## How Has This Been Tested?

manual tests.
npm test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
