### PR TITLE
feat(login): support specification of non-default browser. fixes #62

### DIFF
--- a/src/commands/auth/login.js
+++ b/src/commands/auth/login.js
@@ -39,7 +39,10 @@ class LoginCommand extends ImsBaseCommand {
         })
       }
 
-      let token = await getToken(flags.ctx, { open: flags.open })
+      let token = await getToken(flags.ctx, {
+        open: flags.open,
+        browser: flags.browser
+      })
 
       // decode the token
       if (flags.decode) {
@@ -104,6 +107,9 @@ LoginCommand.flags = {
     allowNo: true,
     default: true,
     description: 'Open the default browser to complete the login'
+  }),
+  browser: flags.string({
+    description: 'specify alternate browser to use when opening login page'
   })
 }
 

--- a/test/commands/auth/login.test.js
+++ b/test/commands/auth/login.test.js
@@ -100,6 +100,27 @@ test('run - success (--bare)', async () => {
   expect(spy2).not.toHaveBeenCalled()
 })
 
+test('run - success (--browser)', async () => {
+  const tokenData = {
+    data: ''
+  }
+
+  const spy = jest.spyOn(command, 'printObject')
+  const spy2 = jest.spyOn(command, 'printConsoleConfig')
+
+  ims.getTokenData.mockImplementation(() => {
+    return tokenData
+  })
+
+  command.argv = ['--browser', 'Firefox']
+  const runResult = command.run()
+  await expect(runResult instanceof Promise).toBeTruthy()
+  await expect(runResult).resolves.not.toThrow()
+  expect(ims.getToken.mock.calls[0][1]).toEqual({ browser: 'Firefox', open: true })
+  expect(spy).toHaveBeenCalled()
+  expect(spy2).toHaveBeenCalled()
+})
+
 test('run - error', async () => {
   const errorMessage = 'my-error'
   const context = 'my-context'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a new flag (`--browser`) which is ultimately passed through `aio-lib-ims` to `aio-lib-ims-oauth` to define an alternate browser.

## Related Issue

#62 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Unit Test
E2E with https://github.com/adobe/aio-lib-ims/pull/91 and  https://github.com/adobe/aio-lib-ims-oauth/pull/44

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
