### PR TITLE
Fix links to source code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ EXAMPLE
     }
 ```
 
-_See code: [src/commands/auth/index.ts](https://github.com/adobe/aio-cli-plugin-auth/blob/2.6.0/src/commands/auth/index.ts)_
+_See code: [src/commands/auth/index.js](https://github.com/adobe/aio-cli-plugin-auth/blob/2.6.0/src/commands/auth/index.js)_
 
 ## `aio auth:ctx`
 
@@ -168,7 +168,7 @@ ALIASES
   $ aio context
 ```
 
-_See code: [src/commands/auth/ctx.ts](https://github.com/adobe/aio-cli-plugin-auth/blob/2.6.0/src/commands/auth/ctx.ts)_
+_See code: [src/commands/auth/ctx.js](https://github.com/adobe/aio-cli-plugin-auth/blob/2.6.0/src/commands/auth/ctx.js)_
 
 ## `aio auth:login`
 
@@ -222,7 +222,7 @@ ALIASES
   $ aio login
 ```
 
-_See code: [src/commands/auth/login.ts](https://github.com/adobe/aio-cli-plugin-auth/blob/2.6.0/src/commands/auth/login.ts)_
+_See code: [src/commands/auth/login.js](https://github.com/adobe/aio-cli-plugin-auth/blob/2.6.0/src/commands/auth/login.js)_
 
 ## `aio auth:logout`
 
@@ -259,7 +259,7 @@ ALIASES
   $ aio logout
 ```
 
-_See code: [src/commands/auth/logout.ts](https://github.com/adobe/aio-cli-plugin-auth/blob/2.6.0/src/commands/auth/logout.ts)_
+_See code: [src/commands/auth/logout.js](https://github.com/adobe/aio-cli-plugin-auth/blob/2.6.0/src/commands/auth/logout.js)_
 <!-- commandsstop -->
 
 

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "execa": "^4.0.0",
     "jest": "^24",
     "jest-junit": "^10.0.0",
-    "stdout-stderr": "^0.1.9",
-    "typescript": "^4.5.3"
+    "stdout-stderr": "^0.1.9"
   },
   "engineStrict": true,
   "engines": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Modified README to change file extensions in links to source code from `.ts` to `.js`.

## Related Issue

## Motivation and Context

This change is required so that links to source files will work. 

## How Has This Been Tested?

Manually tested via personal fork of repository.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
