### PR TITLE
oclif readme --no-aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,9 @@ $ aio auth --help
 # Commands
 <!-- commands -->
 * [`aio auth`](#aio-auth)
-* [`aio auth:ctx`](#aio-authctx)
-* [`aio auth:login`](#aio-authlogin)
-* [`aio auth:logout`](#aio-authlogout)
-* [`aio context`](#aio-context)
-* [`aio ctx`](#aio-ctx)
-* [`aio login`](#aio-login)
-* [`aio logout`](#aio-logout)
+* [`aio auth ctx`](#aio-auth-ctx)
+* [`aio auth login`](#aio-auth-login)
+* [`aio auth logout`](#aio-auth-logout)
 
 ## `aio auth`
 
@@ -88,9 +84,9 @@ USAGE
 DESCRIPTION
   Adobe IMS commands to login and logout.
 
-  The main commands are auth:login to get or create an access token and
+  The main commands are `auth login` to get or create an access token and
 
-  auth:logout to invalidate an access token and thus log out from Adobe IMS.
+  `auth logout` to invalidate an access token and thus log out from Adobe IMS.
 
   Logging in and out is based on configuration of which there may be
 
@@ -146,13 +142,13 @@ EXAMPLES
 
 _See code: [src/commands/auth/index.js](https://github.com/adobe/aio-cli-plugin-auth/blob/3.0.0/src/commands/auth/index.js)_
 
-## `aio auth:ctx`
+## `aio auth ctx`
 
 Manage Adobe IMS contexts.
 
 ```
 USAGE
-  $ aio auth:ctx [--debug <value>] [-v] [-l | -g] [-c <value>] [--list | --value | -s <value> | ]
+  $ aio auth ctx [--debug <value>] [-v] [-l | -g] [-c <value>] [--list | --value | -s <value> | ]
 
 FLAGS
   -c, --ctx=<value>  Name of the Adobe IMS context to use. Default is the current Adobe IMS context
@@ -194,15 +190,13 @@ ALIASES
   $ aio context
 ```
 
-_See code: [src/commands/auth/ctx.js](https://github.com/adobe/aio-cli-plugin-auth/blob/3.0.0/src/commands/auth/ctx.js)_
-
-## `aio auth:login`
+## `aio auth login`
 
 Log in with a certain Adobe IMS context and returns the access token.
 
 ```
 USAGE
-  $ aio auth:login [--debug <value>] [-v] [-l | -g] [-c <value>] [-f] [-d] [-b] [-o]
+  $ aio auth login [--debug <value>] [-v] [-l | -g] [-c <value>] [-f] [-d] [-b] [-o]
 
 FLAGS
   -b, --bare         print access token only
@@ -255,208 +249,13 @@ ALIASES
   $ aio login
 ```
 
-_See code: [src/commands/auth/login.js](https://github.com/adobe/aio-cli-plugin-auth/blob/3.0.0/src/commands/auth/login.js)_
-
-## `aio auth:logout`
+## `aio auth logout`
 
 Log out the current or a named Adobe IMS context.
 
 ```
 USAGE
-  $ aio auth:logout [--debug <value>] [-v] [-l | -g] [-c <value>] [-f]
-
-FLAGS
-  -c, --ctx=<value>  Name of the Adobe IMS context to use. Default is the current Adobe IMS context
-  -f, --force        Invalidate the refresh token as well as all access tokens.
-                     Otherwise only the access token is invalidated. For Adobe IMS
-                     contexts not supporting refresh tokens, this flag has no
-                     effect.
-  -g, --global       global config
-  -l, --local        local config
-  -v, --verbose      Verbose output
-  --debug=<value>    Debug level output
-
-DESCRIPTION
-  Log out the current or a named Adobe IMS context.
-
-  This command can be called multiple times on the same Adobe IMS context with
-
-  out causing any errors. The assumption is that after calling this command
-
-  without an error, the Adobe IMS context's access and refresh tokens have been
-
-  invalidated and removed from persistent storage. Repeatedly calling this
-
-  command will just do nothing.
-
-ALIASES
-  $ aio logout
-```
-
-_See code: [src/commands/auth/logout.js](https://github.com/adobe/aio-cli-plugin-auth/blob/3.0.0/src/commands/auth/logout.js)_
-
-## `aio context`
-
-Manage Adobe IMS contexts.
-
-```
-USAGE
-  $ aio context [--debug <value>] [-v] [-l | -g] [-c <value>] [--list | --value | -s <value> | ]
-
-FLAGS
-  -c, --ctx=<value>  Name of the Adobe IMS context to use. Default is the current Adobe IMS context
-  -g, --global       global config
-  -l, --local        local config
-  -s, --set=<value>  Sets the name of the current local Adobe IMS context
-  -v, --verbose      Verbose output
-  --debug=<value>    Debug level output
-  --list             Names of the Adobe IMS contexts as an array
-  --value            Prints named or current Adobe IMS context data
-
-DESCRIPTION
-  Manage Adobe IMS contexts.
-
-  The following options exist for this command:
-
-  * List the names of the configured Adobe IMS contexts
-
-  * Print the name of the current Adobe IMS context
-
-  * Set the name of the current Adobe IMS context
-
-  * Print the configuration of the current or a named Adobe IMS context
-
-  Currently it is not possible to update the Adobe Adobe IMS context configuration
-
-  using this command. Use the "aio config" commands for this.
-
-  e.g. aio config:set ims.contexts.your_context.your_context_key "your_context_value"
-
-  Please note, that the following IMS context label names is reserved: `cli`
-
-  and should not be used as an IMS context name.
-
-  Also note that the current context can only be set locally.
-
-ALIASES
-  $ aio ctx
-  $ aio context
-```
-
-## `aio ctx`
-
-Manage Adobe IMS contexts.
-
-```
-USAGE
-  $ aio ctx [--debug <value>] [-v] [-l | -g] [-c <value>] [--list | --value | -s <value> | ]
-
-FLAGS
-  -c, --ctx=<value>  Name of the Adobe IMS context to use. Default is the current Adobe IMS context
-  -g, --global       global config
-  -l, --local        local config
-  -s, --set=<value>  Sets the name of the current local Adobe IMS context
-  -v, --verbose      Verbose output
-  --debug=<value>    Debug level output
-  --list             Names of the Adobe IMS contexts as an array
-  --value            Prints named or current Adobe IMS context data
-
-DESCRIPTION
-  Manage Adobe IMS contexts.
-
-  The following options exist for this command:
-
-  * List the names of the configured Adobe IMS contexts
-
-  * Print the name of the current Adobe IMS context
-
-  * Set the name of the current Adobe IMS context
-
-  * Print the configuration of the current or a named Adobe IMS context
-
-  Currently it is not possible to update the Adobe Adobe IMS context configuration
-
-  using this command. Use the "aio config" commands for this.
-
-  e.g. aio config:set ims.contexts.your_context.your_context_key "your_context_value"
-
-  Please note, that the following IMS context label names is reserved: `cli`
-
-  and should not be used as an IMS context name.
-
-  Also note that the current context can only be set locally.
-
-ALIASES
-  $ aio ctx
-  $ aio context
-```
-
-## `aio login`
-
-Log in with a certain Adobe IMS context and returns the access token.
-
-```
-USAGE
-  $ aio login [--debug <value>] [-v] [-l | -g] [-c <value>] [-f] [-d] [-b] [-o]
-
-FLAGS
-  -b, --bare         print access token only
-  -c, --ctx=<value>  Name of the Adobe IMS context to use. Default is the current Adobe IMS context
-  -d, --decode       Decode and display access token data
-  -f, --force        Force logging in. This causes a forced logout on the context first and makes sure to not use any
-                     cached data when calling the plugin.
-  -g, --global       global config
-  -l, --local        local config
-  -o, --[no-]open    Open the default browser to complete the login
-  -v, --verbose      Verbose output
-  --debug=<value>    Debug level output
-
-DESCRIPTION
-  Log in with a certain Adobe IMS context and returns the access token.
-
-  If the Adobe IMS context already has a valid access token set (valid meaning
-
-  at least 10 minutes before expiry), that token is returned.
-
-  Otherwise, if the Adobe IMS context has a valid refresh token set (valid
-
-  meaning at least 10 minutes before expiry) that refresh token is
-
-  exchanged for an access token before returning the access token.
-
-  Lastly, if the Adobe IMS context properties are supported by one of the
-
-  Adobe IMS login plugins, that login plugin is called to guide through
-
-  the IMS login process.
-
-  The currently supported Adobe IMS login plugins are:
-
-  * aio-lib-ims-jwt for JWT token based login supporting
-
-  Adobe I/O Console service integrations.
-
-  * aio-lib-ims-oauth for browser based OAuth2 login. This
-
-  plugin will launch the default browser to guide the user through the
-
-  login process. The plugin itself will *never* see the user's
-
-  password but only receive the authorization token after the
-
-  user has authenticated with Adobe IMS.
-
-ALIASES
-  $ aio login
-```
-
-## `aio logout`
-
-Log out the current or a named Adobe IMS context.
-
-```
-USAGE
-  $ aio logout [--debug <value>] [-v] [-l | -g] [-c <value>] [-f]
+  $ aio auth logout [--debug <value>] [-v] [-l | -g] [-c <value>] [-f]
 
 FLAGS
   -c, --ctx=<value>  Name of the Adobe IMS context to use. Default is the current Adobe IMS context

--- a/bin/run
+++ b/bin/run
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
 
-require('@oclif/command').run()
-.catch(require('@oclif/errors/handle'))
+const oclif = require('@oclif/core')
+
+oclif.run()
+  .then(require('@oclif/core/flush'))
+  .catch(require('@oclif/core/handle'))

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "execa": "^4.0.0",
     "jest": "^27",
     "jest-junit": "^10.0.0",
-    "oclif": "^3.0.1",
+    "oclif": "^3.2.0",
     "stdout-stderr": "^0.1.9"
   },
   "engineStrict": true,
@@ -58,7 +58,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "lint": "eslint src test e2e",
     "pretest": "npm run lint",
-    "prepack": "oclif manifest && oclif readme",
+    "prepack": "oclif manifest && oclif readme --no-aliases",
     "test": "npm run unit-tests",
     "unit-tests": "jest --config test/jest.config.js ---ci -w=2",
     "version": "oclif readme && git add README.md",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "oclif": "^3.2.0",
     "stdout-stderr": "^0.1.9"
   },
-  "engineStrict": true,
   "engines": {
     "node": "^14.18 || ^16.13 || >=18"
   },
@@ -48,6 +47,7 @@
   "oclif": {
     "commands": "./src/commands",
     "bin": "aio",
+    "topicSeparator": " ",
     "hooks": {
       "init": "./src/hooks/upgrade-config-hook.js"
     },

--- a/src/commands/auth/index.js
+++ b/src/commands/auth/index.js
@@ -21,8 +21,8 @@ class IndexCommand extends Command {
 
 IndexCommand.description = `Adobe IMS commands to login and logout.
 
-The main commands are auth:login to get or create an access token and
-auth:logout to invalidate an access token and thus log out from Adobe IMS.
+The main commands are \`auth login\` to get or create an access token and
+\`auth logout\` to invalidate an access token and thus log out from Adobe IMS.
 
 Logging in and out is based on configuration of which there may be
 multiple. Each set of configuration properties, called an Adobe IMS context,


### PR DESCRIPTION
The new oclif README doc generator was listing the aliases as well as commands (which just clutters up the README docs), now there is a new flag --no-aliases. This is an update to the oclif package which is a dev dependency.