### PR TITLE
Prepare for use in alternate CLIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@adobe/aio-lib-core-config": "^3.0.0",
     "@adobe/aio-lib-core-logging": "^2.0.0",
+    "@adobe/aio-lib-env": "^2.0.0",
     "@adobe/aio-lib-ims": "^6.0.0",
     "@oclif/core": "^1.3.5",
     "debug": "^4.1.1",

--- a/src/commands/auth/login.js
+++ b/src/commands/auth/login.js
@@ -14,6 +14,7 @@ const { Flags } = require('@oclif/core')
 const ImsBaseCommand = require('../../ims-base-command')
 const { getTokenData, getToken, invalidateToken, context } = require('@adobe/aio-lib-ims')
 const { CLI } = require('@adobe/aio-lib-ims/src/context')
+const { getCliEnv, STAGE_ENV } = require('@adobe/aio-lib-env')
 
 class LoginCommand extends ImsBaseCommand {
   async run () {
@@ -39,7 +40,23 @@ class LoginCommand extends ImsBaseCommand {
         })
       }
 
-      let token = await getToken(flags.ctx, { open: flags.open })
+      // now we need to set the client_id because the server
+      // stores secrets+scopes for each client_id
+      // server has defaults already for aio-cli-console-auth[-stage]
+      // we also need to differentiate between stage and prod env
+
+      const loginOptions = {
+        open: flags.open
+      }
+      if (process.env.AIO_CLI_IMS_APIKEY) {
+        if (STAGE_ENV === getCliEnv()) {
+          loginOptions.client_id = process.env.AIO_CLI_IMS_APIKEY + '-stage'
+        } else {
+          loginOptions.client_id = process.env.AIO_CLI_IMS_APIKEY
+        }
+      }
+
+      let token = await getToken(flags.ctx, loginOptions)
 
       // decode the token
       if (flags.decode) {

--- a/src/commands/auth/logout.js
+++ b/src/commands/auth/logout.js
@@ -12,13 +12,12 @@ governing permissions and limitations under the License.
 
 const { Flags } = require('@oclif/core')
 const ImsBaseCommand = require('../../ims-base-command')
+const { invalidateToken, context } = require('@adobe/aio-lib-ims')
+const { CLI } = require('@adobe/aio-lib-ims/src/context')
 
 class LogoutCommand extends ImsBaseCommand {
   async run () {
     const { flags } = await this.parse(LogoutCommand)
-
-    const { invalidateToken, context } = require('@adobe/aio-lib-ims')
-    const { CLI } = require('@adobe/aio-lib-ims/src/context')
     const current = await context.getCurrent()
     flags.ctx = flags.ctx || (current || CLI)
     const accessToken = await context.get(`${flags.ctx}.access_token`)

--- a/test/commands/auth/login.test.js
+++ b/test/commands/auth/login.test.js
@@ -153,3 +153,41 @@ test('run - error', async () => {
   runResult = command.run()
   await expect(runResult).rejects.toEqual(new Error(`Cannot get token for context '${context}': ${errorMessage}`))
 })
+
+describe('Use env var for client_id', () => {
+  test('run - success AIO_CLI_IMS_APIKEY - prod', async () => {
+    process.env.AIO_CLI_IMS_APIKEY = 'my-api-key'
+    const tokenData = {
+      data: ''
+    }
+    ims.getToken.mockImplementation(async () => {
+      return tokenData
+    })
+
+    command.argv = []
+    const runResult = command.run()
+    await expect(runResult instanceof Promise).toBeTruthy()
+    await expect(runResult).resolves.not.toThrow()
+    expect(ims.getToken).toHaveBeenCalledWith('cli', { client_id: 'my-api-key', open: true })
+    process.env.AIO_CLI_IMS_APIKEY = undefined
+  })
+
+  test('run - success AIO_CLI_IMS_APIKEY - stage', async () => {
+    process.env.AIO_CLI_IMS_APIKEY = 'my-api-key'
+    process.env.AIO_CLI_ENV = 'stage'
+    const tokenData = {
+      data: ''
+    }
+    ims.getToken.mockImplementation(async () => {
+      return tokenData
+    })
+
+    command.argv = []
+    const runResult = command.run()
+    await expect(runResult instanceof Promise).toBeTruthy()
+    await expect(runResult).resolves.not.toThrow()
+    expect(ims.getToken).toHaveBeenCalledWith('cli', { client_id: 'my-api-key-stage', open: true })
+    process.env.AIO_CLI_IMS_APIKEY = undefined
+    process.env.AIO_CLI_ENV = undefined
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If an alternate CLI sets process.env.AIO_CLI_IMS_APIKEY
We use that as the client_id in our call to the server to login.
We also respect when AIO_CLI_ENV==stage and add a -stage
Note that the server MUST be capable of handling this client_id or it will fail.
Server MUST know the scopes, and client_secret associated with this client_id.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
