### PR TITLE
Remove printing of `where` info after login

### DIFF
--- a/src/commands/auth/login.js
+++ b/src/commands/auth/login.js
@@ -39,18 +39,13 @@ class LoginCommand extends ImsBaseCommand {
         })
       }
 
-      let token = await getToken(flags.ctx, { open: flags.open })
+      const token = await getToken(flags.ctx, { open: flags.open })
 
       // decode the token
       if (flags.decode) {
-        token = getTokenData(token)
-      }
-
-      this.printObject(token)
-
-      if (!flags.bare) {
-        this.log()
-        this.printConsoleConfig()
+        this.printObject(getTokenData(token))
+      } else {
+        this.printObject(token)
       }
     } catch (err) {
       this.debugError('Login failure', err)

--- a/src/commands/auth/login.js
+++ b/src/commands/auth/login.js
@@ -56,7 +56,7 @@ class LoginCommand extends ImsBaseCommand {
         }
       }
 
-      let token = await getToken(flags.ctx, loginOptions)
+      const token = await getToken(flags.ctx, loginOptions)
       // decode the token
       if (flags.decode) {
         this.printObject(getTokenData(token))

--- a/src/ims-base-command.js
+++ b/src/ims-base-command.js
@@ -14,9 +14,6 @@ const { Command, Flags } = require('@oclif/core')
 const hjson = require('hjson')
 const yaml = require('js-yaml')
 const debug = require('debug')
-const config = require('@adobe/aio-lib-core-config')
-
-const CONSOLE_KEY = 'console'
 
 class ImsBaseCommand extends Command {
   async init () {
@@ -70,24 +67,6 @@ class ImsBaseCommand extends Command {
     if (obj != null) {
       print(obj)
     }
-  }
-
-  /**
-   * print current selected console config
-   */
-  printConsoleConfig () {
-    const consoleConfig = {}
-
-    consoleConfig.org = config.get(`${CONSOLE_KEY}.org.name`)
-    consoleConfig.project = config.get(`${CONSOLE_KEY}.project.name`)
-    consoleConfig.workspace = config.get(`${CONSOLE_KEY}.workspace.name`)
-
-    this.log('You are currently in:')
-    this.log(`1. Org: ${consoleConfig.org || '<no org selected>'}`)
-    // note: if no org is selected the console plugin makes sure no project is selected
-    this.log(`2. Project: ${consoleConfig.project || '<no project selected>'}`)
-    // note2: if no project is selected the console plugin makes sure no workspace is selected
-    this.log(`3. Workspace: ${consoleConfig.workspace || '<no workspace selected>'}`)
   }
 }
 

--- a/test/commands/auth/login.test.js
+++ b/test/commands/auth/login.test.js
@@ -43,7 +43,6 @@ test('run - success (no flags)', async () => {
   }
 
   const spy = jest.spyOn(command, 'printObject')
-  const spy2 = jest.spyOn(command, 'printConsoleConfig')
 
   ims.getTokenData.mockImplementation(() => {
     return tokenData
@@ -53,7 +52,6 @@ test('run - success (no flags)', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).resolves.not.toThrow()
   expect(spy).toHaveBeenCalled()
-  expect(spy2).toHaveBeenCalled()
 })
 
 test('run - success (--decode)', async () => {
@@ -63,7 +61,6 @@ test('run - success (--decode)', async () => {
   }
 
   const spy = jest.spyOn(command, 'printObject')
-  const spy2 = jest.spyOn(command, 'printConsoleConfig')
 
   ims.getTokenData.mockImplementation(() => {
     return tokenData
@@ -75,7 +72,6 @@ test('run - success (--decode)', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).resolves.not.toThrow()
   expect(spy).toHaveBeenCalledWith(tokenData)
-  expect(spy2).toHaveBeenCalled()
 })
 
 test('run - success (--bare)', async () => {
@@ -85,7 +81,6 @@ test('run - success (--bare)', async () => {
   }
 
   const spy = jest.spyOn(command, 'printObject')
-  const spy2 = jest.spyOn(command, 'printConsoleConfig')
 
   ims.getToken.mockImplementation(async () => {
     return tokenData
@@ -97,7 +92,6 @@ test('run - success (--bare)', async () => {
   await expect(runResult instanceof Promise).toBeTruthy()
   await expect(runResult).resolves.not.toThrow()
   expect(spy).toHaveBeenCalledWith(tokenData)
-  expect(spy2).not.toHaveBeenCalled()
 })
 
 test('run - error', async () => {

--- a/test/ims-base-command.test.js
+++ b/test/ims-base-command.test.js
@@ -14,7 +14,6 @@ const TheCommand = require('../src/ims-base-command')
 const { stdout } = require('stdout-stderr')
 const hjson = require('hjson')
 const debug = require('debug')
-const config = require('@adobe/aio-lib-core-config')
 
 afterEach(() => {
   jest.resetAllMocks()
@@ -97,58 +96,4 @@ test('printObject', async () => {
   command.argv = []
   await command.printObject({})
   expect(stdout.output).toEqual('')
-})
-
-describe('printConsoleConfig', () => {
-  let mockConfig
-  beforeEach(() => {
-    config.get.mockClear()
-    mockConfig = {
-      'console.org.name': 'Fake Org',
-      'console.project.name': 'Fake Project',
-      'console.workspace.name': 'Fake Workspace'
-    }
-    config.get.mockImplementation(key => mockConfig[key])
-  })
-
-  test('calls config get', () => {
-    command.printConsoleConfig()
-    expect(config.get).toBeCalledWith('console.org.name')
-    expect(config.get).toBeCalledWith('console.project.name')
-    expect(config.get).toBeCalledWith('console.workspace.name')
-  })
-  test('no org, no project, no workspace', () => {
-    delete mockConfig['console.org.name']
-    delete mockConfig['console.project.name']
-    delete mockConfig['console.workspace.name']
-
-    stdout.start()
-    command.printConsoleConfig()
-    expect(stdout.output).toEqual(`You are currently in:
-1. Org: <no org selected>
-2. Project: <no project selected>
-3. Workspace: <no workspace selected>
-`)
-  })
-  test('no project, no workspace', () => {
-    delete mockConfig['console.project.name']
-    delete mockConfig['console.workspace.name']
-    stdout.start()
-    command.printConsoleConfig()
-    expect(stdout.output).toEqual(`You are currently in:
-1. Org: Fake Org
-2. Project: <no project selected>
-3. Workspace: <no workspace selected>
-`)
-  })
-  test('no workspace', () => {
-    delete mockConfig['console.workspace.name']
-    stdout.start()
-    command.printConsoleConfig()
-    expect(stdout.output).toEqual(`You are currently in:
-1. Org: Fake Org
-2. Project: Fake Project
-3. Workspace: <no workspace selected>
-`)
-  })
 })


### PR DESCRIPTION


Outputting info from config after a login does not make sense for other CLIs.
This plugin can and will be used by multiple CLIs.
Question: Should be get rid of the 'bare' flag entirely?

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

#52 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
