### PR TITLE
fix: ACNA-2802 - code links in README point to a .ts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,6 @@ $ aio auth --help
 * [`aio auth ctx`](#aio-auth-ctx)
 * [`aio auth login`](#aio-auth-login)
 * [`aio auth logout`](#aio-auth-logout)
-* [`aio context`](#aio-context)
-* [`aio ctx`](#aio-ctx)
-* [`aio login`](#aio-login)
-* [`aio logout`](#aio-logout)
 
 ## `aio auth`
 
@@ -133,7 +129,7 @@ EXAMPLES
     }
 ```
 
-_See code: [src/commands/auth/index.ts](https://github.com/adobe/aio-cli-plugin-auth/blob/4.0.0/src/commands/auth/index.ts)_
+_See code: [src/commands/auth/index.js](https://github.com/adobe/aio-cli-plugin-auth/blob/4.0.0/src/commands/auth/index.js)_
 
 ## `aio auth ctx`
 
@@ -178,7 +174,7 @@ ALIASES
   $ aio context
 ```
 
-_See code: [src/commands/auth/ctx.ts](https://github.com/adobe/aio-cli-plugin-auth/blob/4.0.0/src/commands/auth/ctx.ts)_
+_See code: [src/commands/auth/ctx.js](https://github.com/adobe/aio-cli-plugin-auth/blob/4.0.0/src/commands/auth/ctx.js)_
 
 ## `aio auth login`
 
@@ -229,7 +225,7 @@ ALIASES
   $ aio login
 ```
 
-_See code: [src/commands/auth/login.ts](https://github.com/adobe/aio-cli-plugin-auth/blob/4.0.0/src/commands/auth/login.ts)_
+_See code: [src/commands/auth/login.js](https://github.com/adobe/aio-cli-plugin-auth/blob/4.0.0/src/commands/auth/login.js)_
 
 ## `aio auth logout`
 
@@ -264,175 +260,7 @@ ALIASES
   $ aio logout
 ```
 
-_See code: [src/commands/auth/logout.ts](https://github.com/adobe/aio-cli-plugin-auth/blob/4.0.0/src/commands/auth/logout.ts)_
-
-## `aio context`
-
-Manage Adobe IMS contexts.
-
-```
-USAGE
-  $ aio context [--debug <value>] [-v] [-l | -g] [-c <value>] [--list | --value | -s <value> | ]
-
-FLAGS
-  -c, --ctx=<value>  Name of the Adobe IMS context to use. Default is the current Adobe IMS context
-  -g, --global       global config
-  -l, --local        local config
-  -s, --set=<value>  Sets the name of the current local Adobe IMS context
-  -v, --verbose      Verbose output
-  --debug=<value>    Debug level output
-  --list             Names of the Adobe IMS contexts as an array
-  --value            Prints named or current Adobe IMS context data
-
-DESCRIPTION
-  Manage Adobe IMS contexts.
-
-  The following options exist for this command:
-
-  * List the names of the configured Adobe IMS contexts
-  * Print the name of the current Adobe IMS context
-  * Set the name of the current Adobe IMS context
-  * Print the configuration of the current or a named Adobe IMS context
-
-  Currently it is not possible to update the Adobe Adobe IMS context configuration
-  using this command. Use the "aio config" commands for this.
-  e.g. aio config:set ims.contexts.your_context.your_context_key "your_context_value"
-
-  Please note, that the following IMS context label names is reserved: `cli`
-  and should not be used as an IMS context name.
-
-  Also note that the current context can only be set locally.
-
-
-ALIASES
-  $ aio ctx
-  $ aio context
-```
-
-## `aio ctx`
-
-Manage Adobe IMS contexts.
-
-```
-USAGE
-  $ aio ctx [--debug <value>] [-v] [-l | -g] [-c <value>] [--list | --value | -s <value> | ]
-
-FLAGS
-  -c, --ctx=<value>  Name of the Adobe IMS context to use. Default is the current Adobe IMS context
-  -g, --global       global config
-  -l, --local        local config
-  -s, --set=<value>  Sets the name of the current local Adobe IMS context
-  -v, --verbose      Verbose output
-  --debug=<value>    Debug level output
-  --list             Names of the Adobe IMS contexts as an array
-  --value            Prints named or current Adobe IMS context data
-
-DESCRIPTION
-  Manage Adobe IMS contexts.
-
-  The following options exist for this command:
-
-  * List the names of the configured Adobe IMS contexts
-  * Print the name of the current Adobe IMS context
-  * Set the name of the current Adobe IMS context
-  * Print the configuration of the current or a named Adobe IMS context
-
-  Currently it is not possible to update the Adobe Adobe IMS context configuration
-  using this command. Use the "aio config" commands for this.
-  e.g. aio config:set ims.contexts.your_context.your_context_key "your_context_value"
-
-  Please note, that the following IMS context label names is reserved: `cli`
-  and should not be used as an IMS context name.
-
-  Also note that the current context can only be set locally.
-
-
-ALIASES
-  $ aio ctx
-  $ aio context
-```
-
-## `aio login`
-
-Log in with a certain Adobe IMS context and returns the access token.
-
-```
-USAGE
-  $ aio login [--debug <value>] [-v] [-l | -g] [-c <value>] [-f] [-d] [-b] [-o]
-
-FLAGS
-  -b, --bare         print access token only
-  -c, --ctx=<value>  Name of the Adobe IMS context to use. Default is the current Adobe IMS context
-  -d, --decode       Decode and display access token data
-  -f, --force        Force logging in. This causes a forced logout on the context first and makes sure to not use any
-                     cached data when calling the plugin.
-  -g, --global       global config
-  -l, --local        local config
-  -o, --[no-]open    Open the default browser to complete the login
-  -v, --verbose      Verbose output
-  --debug=<value>    Debug level output
-
-DESCRIPTION
-  Log in with a certain Adobe IMS context and returns the access token.
-
-  If the Adobe IMS context already has a valid access token set (valid meaning
-  at least 10 minutes before expiry), that token is returned.
-
-  Otherwise, if the Adobe IMS context has a valid refresh token set (valid
-  meaning at least 10 minutes before expiry) that refresh token is
-  exchanged for an access token before returning the access token.
-
-  Lastly, if the Adobe IMS context properties are supported by one of the
-  Adobe IMS login plugins, that login plugin is called to guide through
-  the IMS login process.
-
-  The currently supported Adobe IMS login plugins are:
-
-  * aio-lib-ims-jwt for JWT token based login supporting
-  Adobe I/O Console service integrations.
-  * aio-lib-ims-oauth for browser based OAuth2 login. This
-  plugin will launch the default browser to guide the user through the
-  login process. The plugin itself will *never* see the user's
-  password but only receive the authorization token after the
-  user has authenticated with Adobe IMS.
-
-
-ALIASES
-  $ aio login
-```
-
-## `aio logout`
-
-Log out the current or a named Adobe IMS context.
-
-```
-USAGE
-  $ aio logout [--debug <value>] [-v] [-l | -g] [-c <value>] [-f]
-
-FLAGS
-  -c, --ctx=<value>  Name of the Adobe IMS context to use. Default is the current Adobe IMS context
-  -f, --[no-]force   Invalidate the refresh token as well as all access tokens.
-                     Otherwise only the access token is invalidated. For Adobe IMS
-                     contexts not supporting refresh tokens, this flag has no
-                     effect.
-  -g, --global       global config
-  -l, --local        local config
-  -v, --verbose      Verbose output
-  --debug=<value>    Debug level output
-
-DESCRIPTION
-  Log out the current or a named Adobe IMS context.
-
-  This command can be called multiple times on the same Adobe IMS context with
-  out causing any errors. The assumption is that after calling this command
-  without an error, the Adobe IMS context's access and refresh tokens have been
-  invalidated and removed from persistent storage. Repeatedly calling this
-  command will just do nothing.
-
-
-ALIASES
-  $ aio logout
-```
+_See code: [src/commands/auth/logout.js](https://github.com/adobe/aio-cli-plugin-auth/blob/4.0.0/src/commands/auth/logout.js)_
 <!-- commandsstop -->
 
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ora": "^4.0.3"
   },
   "devDependencies": {
-    "@adobe/eslint-config-aio-lib-config": "^2.0.1",
+    "@adobe/eslint-config-aio-lib-config": "^3.0.0",
     "chalk": "^4.0.0",
     "eslint": "^8.46.0",
     "eslint-config-oclif": "^4.0.0",
@@ -31,8 +31,7 @@
     "jest": "^29",
     "jest-junit": "^16.0.0",
     "oclif": "^3.2.0",
-    "stdout-stderr": "^0.1.9",
-    "typescript": "^5.1.6"
+    "stdout-stderr": "^0.1.9"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
closes #126 

## How Has This Been Tested?

1. rm -rf node_modules
2. npm i
3. npm test
4. npm run prepack
5. Inspect README.md for `See code:` links (should point to the `.js` file)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
