### PR TITLE
fix: add --local support for login

### DIFF
--- a/src/commands/auth/login.js
+++ b/src/commands/auth/login.js
@@ -36,7 +36,8 @@ class LoginCommand extends ImsBaseCommand {
       if (flags.ctx === CLI) {
         await context.setCli({
           'cli.bare-output': flags.bare
-        })
+        },
+        !!flags.local)
       }
 
       // now we need to set the client_id because the server

--- a/test/commands/auth/login.test.js
+++ b/test/commands/auth/login.test.js
@@ -54,6 +54,46 @@ test('run - success (no flags)', async () => {
   expect(spy).toHaveBeenCalled()
 })
 
+describe('cli context', () => {
+  test('run success (--local)', async () => {
+    const tokenData = { data: '' }
+    ims.getTokenData.mockImplementation(() => tokenData)
+
+    command.argv = ['--ctx', 'cli', '--local']
+    const runResult = command.run([])
+
+    await expect(runResult instanceof Promise).toBeTruthy()
+    await expect(runResult).resolves.not.toThrow()
+    expect(ims.context.setCli).toHaveBeenCalledWith(expect.any(Object), true)
+  })
+
+  test('run success (--global)', async () => {
+    const tokenData = { data: '' }
+
+    ims.getTokenData.mockImplementation(() => tokenData)
+
+    command.argv = ['--ctx', 'cli', '--global']
+    const runResult = command.run([])
+
+    await expect(runResult instanceof Promise).toBeTruthy()
+    await expect(runResult).resolves.not.toThrow()
+    expect(ims.context.setCli).toHaveBeenCalledWith(expect.any(Object), false)
+  })
+
+  test('run success (no flag - should be global as default)', async () => {
+    const tokenData = { data: '' }
+
+    ims.getTokenData.mockImplementation(() => tokenData)
+
+    command.argv = ['--ctx', 'cli']
+    const runResult = command.run([])
+
+    await expect(runResult instanceof Promise).toBeTruthy()
+    await expect(runResult).resolves.not.toThrow()
+    expect(ims.context.setCli).toHaveBeenCalledWith(expect.any(Object), false)
+  })
+})
+
 test('run - success (--decode)', async () => {
   const context = 'my-context'
   const tokenData = {


### PR DESCRIPTION
## Motivation and Context

This allows the login access tokens to be saved locally to the project, instead of globally for the user.

## How Has This Been Tested?

- npm test
- `aio login --local` on one project in stage
- `aio login --local` on another project in prod
- `aio app deploy` for both projects simultaneously, both should succeed

This can be used for projects that need to be logged in different Orgs (not just prod/stage).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
